### PR TITLE
Starting TREE header from 0 instead of nCores

### DIFF
--- a/growforest/growforest.go
+++ b/growforest/growforest.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/ryanbressler/CloudForest"
-	"github.com/ryanbressler/CloudForest/stats"
 	"io"
 	"log"
 	"math"
@@ -17,6 +15,9 @@ import (
 	"runtime/pprof"
 	"sync"
 	"time"
+
+	"github.com/ryanbressler/CloudForest"
+	"github.com/ryanbressler/CloudForest/stats"
 )
 
 func main() {
@@ -678,7 +679,7 @@ func main() {
 					}
 
 					if forestwriter != nil && foresti == nForest-1 {
-						forestwriter.WriteTree(tree, treesStarted)
+						forestwriter.WriteTree(tree, treesFinished)
 					}
 
 					if scikitforest != "" {


### PR DESCRIPTION
The tree number in the header was starting from `nCores` instead of 0, since `treesStarted` is initialized to it.

Inside `WriteTree` this number is only used to print the header so I changed it to `treesFinished` since I noticed `--progress` uses it and reports the tree numbers correctly.

Output of `grep TREE` on the `.sf` file before:

    TREE=16,TARGET="B:ispathogenic"
    TREE=17,TARGET="B:ispathogenic"
    TREE=18,TARGET="B:ispathogenic"
    TREE=19,TARGET="B:ispathogenic"
    TREE=20,TARGET="B:ispathogenic"
    (...)
    TREE=98,TARGET="B:ispathogenic"
    TREE=99,TARGET="B:ispathogenic"
    TREE=100,TARGET="B:ispathogenic"
    TREE=100,TARGET="B:ispathogenic"
    TREE=100,TARGET="B:ispathogenic"
    (repeats till the end)

Output of `grep TREE` on the `.sf` file after:

    TREE=0,TARGET="B:ispathogenic"
    TREE=1,TARGET="B:ispathogenic"
    TREE=2,TARGET="B:ispathogenic"
    TREE=3,TARGET="B:ispathogenic"
    TREE=4,TARGET="B:ispathogenic"
    (...)
    TREE=94,TARGET="B:ispathogenic"
    TREE=95,TARGET="B:ispathogenic"
    TREE=96,TARGET="B:ispathogenic"
    TREE=97,TARGET="B:ispathogenic"
    TREE=98,TARGET="B:ispathogenic"
    TREE=99,TARGET="B:ispathogenic"
    <<EOF>>

Same as #49, but now tracking the right branch on the fork.