### PR TITLE
Update grow rf

### DIFF
--- a/featurematrix.go
+++ b/featurematrix.go
@@ -447,21 +447,7 @@ func LoadAFM(filename string) (fm *FeatureMatrix, err error) {
 func ParseFeature(record []string) Feature {
 	capacity := len(record)
 	switch record[0][0:2] {
-	case "N:":
-		f := &DenseNumFeature{
-			nil,
-			make([]bool, 0, capacity),
-			record[0],
-			false}
-		f.NumData = make([]float64, 0, capacity)
-
-		for i := 1; i < len(record); i++ {
-			f.Append(record[i])
-
-		}
-		return f
-
-	default:
+	case "C:":
 		f := &DenseCatFeature{
 			&CatMap{make(map[string]int, 0),
 				make([]string, 0, 0)},
@@ -476,6 +462,21 @@ func ParseFeature(record []string) Feature {
 
 		}
 		return f
+
+	default:
+		f := &DenseNumFeature{
+			nil,
+			make([]bool, 0, capacity),
+			record[0],
+			false}
+		f.NumData = make([]float64, 0, capacity)
+
+		for i := 1; i < len(record); i++ {
+			f.Append(record[i])
+		}
+
+		return f
+
 	}
 
 }

--- a/forrest.go
+++ b/forrest.go
@@ -1,7 +1,5 @@
 package CloudForest
 
-import ()
-
 //Forest represents a collection of decision trees grown to predict Target.
 type Forest struct {
 	//Forest string
@@ -29,21 +27,8 @@ itter indicates weather to use iterative splitting for all categorical features 
 with more then 6 categories.
 */
 
-func GrowRandomForest(fm *FeatureMatrix,
-	target Target,
-	candidates []int,
-	nSamples int,
-	mTry int,
-	nTrees int,
-	leafSize int,
-	maxDepth int,
-	splitmissing bool,
-	force bool,
-	vet bool,
-	evaloob bool,
-	importance *[]*RunningMean) (f *Forest) {
-
-	f = &Forest{target.GetName(), make([]*Tree, 0, nTrees), 0.0}
+func GrowRandomForest(fm *FeatureMatrix, target Target, candidates []int, nSamples int, mTry int, nTrees int, leafSize int, maxDepth int, splitmissing bool, force bool, vet bool, evaloob bool, importance *[]*RunningMean) *Forest {
+	f := &Forest{target.GetName(), make([]*Tree, 0, nTrees), 0.0}
 
 	switch target.(type) {
 	case TargetWithIntercept:
@@ -57,7 +42,10 @@ func GrowRandomForest(fm *FeatureMatrix,
 		nCases := fm.Data[0].Length()
 		cases := SampleWithReplacment(nSamples, nCases)
 
-		f.Trees = append(f.Trees, NewTree())
+		tree := NewTree()
+		tree.Target = target.GetName()
+		f.Trees = append(f.Trees, tree)
+
 		f.Trees[i].Grow(fm, target, cases, candidates, nil, mTry, leafSize, maxDepth, splitmissing, force, vet, evaloob, false, importance, nil, allocs)
 		switch target.(type) {
 		case BoostingTarget:
@@ -65,5 +53,5 @@ func GrowRandomForest(fm *FeatureMatrix,
 			f.Trees[i].Weight = target.(BoostingTarget).Boost(ls, ps)
 		}
 	}
-	return
+	return f
 }

--- a/numballotbox.go
+++ b/numballotbox.go
@@ -2,7 +2,6 @@ package CloudForest
 
 import (
 	"fmt"
-	"log"
 	"math"
 	"strconv"
 )
@@ -73,9 +72,10 @@ func (bb *NumBallotBox) TallySquaredError(feature Feature) (e float64) {
 		}
 	}
 	if c == 0.0 {
-		log.Fatal("TallyError with 0 count!")
+		e = math.NaN()
+	} else {
+		e = e / float64(c)
 	}
-	e = e / float64(c)
 
 	return
 

--- a/utils.go
+++ b/utils.go
@@ -100,7 +100,8 @@ func (sc *SparseCounter) WriteTsv(writer io.Writer) {
 	for i := range sc.Map {
 		for j, val := range sc.Map[i] {
 			if _, err := fmt.Fprintf(writer, "%v\t%v\t%v\n", i, j, val); err != nil {
-				log.Fatal(err)
+				log.Println(err)
+				return
 			}
 		}
 	}


### PR DESCRIPTION
a couple of minor things: 
 - `Parse` numeric fields by default, instead of categorical 
 - assigns a `target` field to the trees in the `GrowRandomForest` function