### PR TITLE
Use local rand.Rand object in FeatureMatrix.BestSplitter

### DIFF
--- a/densecatfeature.go
+++ b/densecatfeature.go
@@ -657,7 +657,7 @@ func (f *DenseCatFeature) BestCatSplit(target Target,
 		bits = i
 		if !useExhaustive {
 			//generate random partition
-			bits = rand.Int()
+			bits = allocs.Rnd.Int()
 		}
 
 		// //check the value of the j'th bit of i and
@@ -859,7 +859,6 @@ func (f *DenseCatFeature) BestCatSplitBig(target Target, cases *[]int, parentImp
 
 	bits := big.NewInt(1)
 
-	var randgn *rand.Rand
 	var maxPart *big.Int
 	useExhaustive := nCats <= maxEx
 	nPartitions := big.NewInt(2)
@@ -871,7 +870,6 @@ func (f *DenseCatFeature) BestCatSplitBig(target Target, cases *[]int, parentImp
 		nPartitions.Lsh(nPartitions, uint(maxEx-2))
 		maxPart = big.NewInt(2)
 		maxPart.Lsh(maxPart, uint(nCats-2))
-		randgn = rand.New(rand.NewSource(0))
 	}
 
 	//iteratively build a combination of categories until they
@@ -881,7 +879,7 @@ func (f *DenseCatFeature) BestCatSplitBig(target Target, cases *[]int, parentImp
 		bits.Set(i)
 		if !useExhaustive {
 			//generate random partition
-			bits.Rand(randgn, maxPart)
+			bits.Rand(allocs.Rnd, maxPart)
 		}
 
 		//check the value of the j'th bit of i and

--- a/densecatfeature.go
+++ b/densecatfeature.go
@@ -1161,13 +1161,13 @@ func (f *DenseCatFeature) Shuffle() {
 }
 
 //ShuffleCases does an inplace shuffle of the specified cases
-func (f *DenseCatFeature) ShuffleCases(cases *[]int) {
+func (f *DenseCatFeature) ShuffleCases(cases *[]int, allocs *BestSplitAllocs) {
 	capacity := len(*cases)
 	//shuffle
 	for j := 0; j < capacity; j++ {
 
 		targeti := (*cases)[j]
-		sourcei := (*cases)[j+rand.Intn(capacity-j)]
+		sourcei := (*cases)[j+allocs.Rnd.Intn(capacity-j)]
 		missing := f.Missing[targeti]
 		f.Missing[targeti] = f.Missing[sourcei]
 		f.Missing[sourcei] = missing

--- a/densecatfeature_test.go
+++ b/densecatfeature_test.go
@@ -3,6 +3,7 @@ package CloudForest
 import (
 	"fmt"
 	"testing"
+	"math/rand"
 )
 
 func TestCatFeature(t *testing.T) {
@@ -234,6 +235,8 @@ func TestBigCatFeature(t *testing.T) {
 	bigfm := FeatureMatrix{[]Feature{bigf},
 		map[string]int{bigf.Name: 0},
 		[]string{bigf.Name}}
+
+	rand.Seed(1) // we want the same results every time for tests
 
 	allocs := NewBestSplitAllocs(40, boolf)
 

--- a/densenumfeature.go
+++ b/densenumfeature.go
@@ -312,7 +312,7 @@ func (f *DenseNumFeature) BestNumSplit(target Target,
 		}
 		lasti := leafSize - 1
 
-		if randomSplit {
+		if randomSplit  && stop > leafSize {
 			leafSize = leafSize + allocs.Rnd.Intn(stop-leafSize)
 			lasti = leafSize - 1
 			stop = leafSize + 1
@@ -608,13 +608,13 @@ func (f *DenseNumFeature) Shuffle() {
 }
 
 //ShuffleCases does an inplace shuffle of the specified cases
-func (f *DenseNumFeature) ShuffleCases(cases *[]int) {
+func (f *DenseNumFeature) ShuffleCases(cases *[]int, allocs *BestSplitAllocs) {
 	capacity := len(*cases)
 	//shuffle
 	for j := 0; j < capacity; j++ {
 
 		targeti := (*cases)[j]
-		sourcei := (*cases)[j+rand.Intn(capacity-j)]
+		sourcei := (*cases)[j+allocs.Rnd.Intn(capacity-j)]
 		missing := f.Missing[targeti]
 		f.Missing[targeti] = f.Missing[sourcei]
 		f.Missing[sourcei] = missing

--- a/densenumfeature.go
+++ b/densenumfeature.go
@@ -313,7 +313,7 @@ func (f *DenseNumFeature) BestNumSplit(target Target,
 		lasti := leafSize - 1
 
 		if randomSplit {
-			leafSize = leafSize + rand.Intn(stop-leafSize)
+			leafSize = leafSize + allocs.Rnd.Intn(stop-leafSize)
 			lasti = leafSize - 1
 			stop = leafSize + 1
 

--- a/featureinterfaces.go
+++ b/featureinterfaces.go
@@ -34,7 +34,7 @@ type Feature interface {
 	Copy() (copy Feature)
 	CopyInTo(copy Feature)
 	Shuffle()
-	ShuffleCases(cases *[]int)
+	ShuffleCases(cases *[]int, allocs *BestSplitAllocs)
 	ImputeMissing()
 	GetName() string
 	Append(v string)

--- a/featurematrix.go
+++ b/featurematrix.go
@@ -198,7 +198,7 @@ func (fm *FeatureMatrix) BestSplitter(target Target,
 		if lcans > nDrawnConstants+lastSample {
 
 			randi = lastSample
-			randi += rand.Intn(lcans - nDrawnConstants - lastSample)
+			randi += allocs.Rnd.Intn(lcans - nDrawnConstants - lastSample)
 			//randi = lastSample + rand.Intn(nnonconstant-lastSample)
 			if randi >= lcans-nConstants {
 				nDrawnConstants++

--- a/featurematrix.go
+++ b/featurematrix.go
@@ -234,7 +234,7 @@ func (fm *FeatureMatrix) BestSplitter(target Target,
 				casept = oob
 			}
 
-			allocs.ContrastTarget.(Feature).ShuffleCases(casept)
+			allocs.ContrastTarget.(Feature).ShuffleCases(casept, allocs)
 			_, vetImp, _ = f.BestSplit(allocs.ContrastTarget, casept, parentImp, leafSize, extraRandom, allocs)
 			inerImp = inerImp - vetImp
 		}

--- a/splitallocations.go
+++ b/splitallocations.go
@@ -1,6 +1,8 @@
 package CloudForest
 
-import ()
+import (
+	"math/rand"
+)
 
 //BestSplitAllocs contains reusable allocations for split searching and evaluation.
 //Seprate instances should be used in each go routing doing learning.
@@ -27,6 +29,7 @@ type BestSplitAllocs struct {
 	SortVals       []float64
 	Sorter         *SortableFeature //for learning from numerical features
 	ContrastTarget Target
+	Rnd            *rand.Rand //prevent contention on global rand source
 }
 
 //NewBestSplitAllocs initializes all of the reusable allocations for split
@@ -63,6 +66,8 @@ func NewBestSplitAllocs(nTotalCases int, target Target) (bsa *BestSplitAllocs) {
 		make([]float64, nTotalCases, nTotalCases),
 		&SortableFeature{make([]float64, nTotalCases, nTotalCases),
 			nil},
-		target.(Feature).Copy().(Target)}
+		target.(Feature).Copy().(Target),
+		rand.New(rand.NewSource(rand.Int63())),
+	}
 	return
 }


### PR DESCRIPTION
- When learning on many threads, there is a _lot_ of contention
  on the mutex in global rand source for no real reason.
- In my use case, results in speed up from 4m30s to 33s
  on 64 core system (7.7x faster)

ppref graphs (**large images!**):
- before: http://i.imgur.com/o0SxiM7.jpg
- after: http://i.imgur.com/BeTErB8.jpg
